### PR TITLE
ページ遷移先が同一コンポーネントの場合にトランジションが発火しない不具合を修正

### DIFF
--- a/src/js/components/App.vue
+++ b/src/js/components/App.vue
@@ -2,7 +2,7 @@
   <div id="app">
     <blog-menu />
     <transition name="content" appear mode="out-in">
-      <router-view></router-view>
+      <router-view :key="$route.path"></router-view>
     </transition>
   </div>
 </template>


### PR DESCRIPTION
vue-routerの仕様として、同じコンポーネントは再利用するというものがあるため、
keyを持たせて異なる要素だと明示し、強制的に再読込させるようにした

This PR fixes #4 .