### PR TITLE
CMSが途中で動かなくなるのを修正

### DIFF
--- a/public/admin/index.html
+++ b/public/admin/index.html
@@ -16,7 +16,7 @@
                 tables: true,
                 breaks: true,
                 highlight(code, lang) {
-                    return lang ? hljs.highlight(lang, code).value : hljs.highlightAuto(code).value
+                    return hljs.getLanguage(lang) ? hljs.highlight(lang, code).value : hljs.highlightAuto(code).value
                 },
             })
 


### PR DESCRIPTION
highlighjsが存在しない言語を読み込もうとしてエラー -> 何故かReactがずっとエラーになっていたため、
存在しない言語が指定された時は`highlightAuto`を呼ぶように変更

fixes #29 