### PR TITLE
記事HTMLを生成するようにした

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ public/amp
 public/posts.json
 public/bundle.js
 public/sitemap.xml
+public/index.html

--- a/package.json
+++ b/package.json
@@ -10,12 +10,14 @@
     "compile:markdown": "find posts -name \"*.md\" -type f|xargs -I{} sh -c 'echo {}|node scripts/md2json.js > public/$(echo {}|sed -e \"s/\\.md$/.json/\")'",
     "compile:amp": "find public/posts -name \"*.json\" -type f|node scripts/make-amp/index.js",
     "compile:js": "NODE_ENV=production webpack -p",
+    "compile:html": "find public/posts -name \"*.json\" -type f|node scripts/make-html/index.js",
     "build:app": "npm run compile:js",
     "build:posts": "npm run create:directories && npm run compile:markdown && npm run build:list",
     "build:amp": "npm run create:amp-directories && npm run compile:amp",
+    "build:html": "npm run compile:html",
     "build:sitemap": "HOST_NAME=https://log.pocka.io node scripts/make-sitemap.js",
     "build:list": "find posts -name \"*.md\" -type f|node scripts/make-posts-list.js > public/posts.json",
-    "build": "npm run build:posts && npm run build:sitemap && npm run build:amp && npm run build:app",
+    "build": "npm run build:posts && npm run build:sitemap && npm run build:amp && npm run build:html && npm run build:app",
     "dev": "webpack-dev-server --hot --host 0.0.0.0"
   },
   "repository": {

--- a/scripts/make-html/buildHTML.js
+++ b/scripts/make-html/buildHTML.js
@@ -1,0 +1,28 @@
+const path = require('path')
+
+const pug = require('pug')
+
+const template = path.resolve(__dirname, '../../src/html/index.pug')
+const publicDir = path.resolve(__dirname, '../../public/')
+
+/**
+ * Lazy pug renderer
+ */
+const renderer = {
+  _renderer: null,
+  get render() {
+    if (!renderer._renderer) {
+      renderer._renderer = pug.compileFile(template)
+    }
+
+    return renderer._renderer
+  }
+}
+
+/**
+ * @param {object} post
+ * @returns {string} HTML
+ */
+exports.buildHTML = post => {
+  return renderer.render({ post })
+}

--- a/scripts/make-html/index.js
+++ b/scripts/make-html/index.js
@@ -1,0 +1,56 @@
+const path = require('path')
+const readline = require('readline')
+
+const fs = require('mz/fs')
+
+const moment = require('moment')
+
+const { buildHTML } = require('./buildHTML')
+
+const destDir = path.resolve(__dirname, '../../public')
+
+const { stdin, stdout } = process
+
+const rl = readline.createInterface({
+  input: stdin,
+  output: stdout
+})
+
+let jsonFiles = []
+
+rl.on('line', line => {
+  jsonFiles.push(line)
+})
+
+rl.on('close', async () => {
+  rl.close()
+
+  // 記事HTMLの作成
+  await Promise.all(
+    jsonFiles.map(async file => {
+      const json = require(path.resolve(__dirname, '../../', file))
+
+      const post = Object.assign({}, json, {
+        createdAt: moment(new Date(json.createdAt)).format('YYYY/MM/DD'),
+        updatedAt: moment(new Date(json.updatedAt)).format('YYYY/MM/DD')
+      })
+
+      const html = buildHTML(post)
+
+      const destPath = path.resolve(
+        destDir,
+        'posts',
+        path.basename(file).replace(/\.json$/, '.html')
+      )
+
+      return fs.writeFile(destPath, html)
+    })
+  )
+
+  // index.htmlの作成
+  const html = buildHTML()
+
+  const savePath = path.resolve(destDir, 'index.html')
+
+  await fs.writeFile(savePath, html)
+})

--- a/src/html/ga.js
+++ b/src/html/ga.js
@@ -1,0 +1,21 @@
+;(function(i, s, o, g, r, a, m) {
+  i['GoogleAnalyticsObject'] = r
+  ;(i[r] =
+    i[r] ||
+    function() {
+      ;(i[r].q = i[r].q || []).push(arguments)
+    }),
+    (i[r].l = 1 * new Date())
+  ;(a = s.createElement(o)), (m = s.getElementsByTagName(o)[0])
+  a.async = 1
+  a.src = g
+  m.parentNode.insertBefore(a, m)
+})(
+  window,
+  document,
+  'script',
+  'https://www.google-analytics.com/analytics.js',
+  'ga'
+)
+ga('create', 'UA-40502013-5', 'auto')
+ga('send', 'pageview')

--- a/src/html/index.pug
+++ b/src/html/index.pug
@@ -1,0 +1,34 @@
+doctype
+html
+  head
+    meta(charset="utf-8")
+    meta(name="viewport", content="width=device-width,initial-scale=1")
+    link(rel="me", href="https://github.com/pocka", type="text/html")
+    link(rel="me", href="https://twitter.com/pockaquel", type="text/html")
+    link(rel="preload", href="https://fonts.googleapis.com/earlyaccess/mplus1p.css", as="style")
+    link(rel="preload", href="https://fonts.googleapis.com/css?family=Cairo|Raleway|Saira+Semi+Condensed", as="style")
+    link(rel="preload", href="https://cdnjs.cloudflare.com/ajax/libs/bulma/0.5.2/css/bulma.min.css", as="style")
+    link(rel="preload", href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.12.0/styles/monokai-sublime.min.css", as="style")
+    script(src="/bundle.js", defer)
+    style
+      include initialView.css
+    title= post ? post.title : 'log.pocka.io'
+    - if (post) {
+      meta(name="description", content=post.description)
+      meta(name="keywords", content=post.tags.join(','))
+      meta(name="author", content=post.author)
+      link(rel="amphtml", href=`https://log.pocka.io/amp/${post.name}.html`)
+      meta(property="og:title", content=post.title)
+      meta(property="og:type", content="article")
+      meta(property="og:image", content="https://avatars3.githubusercontent.com/u/13316015?s=460&v=4")
+      meta(property="og:url", content=`https://log.pocka.io/posts/${post.name}`)
+      meta(property="og:description", content=post.description)
+      meta(property="og:locale", content="ja_JP")
+    - }
+  body
+    #initial_view
+      .initial-loader-wrapper
+        .initial-loader
+    #app
+    script
+      include ga.js

--- a/src/html/initialView.css
+++ b/src/html/initialView.css
@@ -1,4 +1,4 @@
-<!DOCTYPE html><html><head><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1"><link rel="me" href="https://github.com/pocka" type="text/html"><link rel="me" href="https://twitter.com/pockaquel" type="text/html"><link rel="preload" href="https://fonts.googleapis.com/earlyaccess/mplus1p.css" as="style"><link rel="preload" href="https://fonts.googleapis.com/css?family=Cairo|Raleway|Saira+Semi+Condensed" as="style"><link rel="preload" href="https://cdnjs.cloudflare.com/ajax/libs/bulma/0.5.2/css/bulma.min.css" as="style"><link rel="preload" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.12.0/styles/monokai-sublime.min.css" as="style"><script src="/bundle.js" defer></script><style>.initial-loader,
+.initial-loader,
 .initial-loader:before,
 .initial-loader:after {
 	border-radius: 50%;
@@ -94,25 +94,3 @@
 #initial_view.css-loaded.app-loaded {
 	opacity: 0;
 }
-</style><title>log.pocka.io</title></head><body><div id="initial_view"><div class="initial-loader-wrapper"><div class="initial-loader"></div></div></div><div id="app"></div><script>;(function(i, s, o, g, r, a, m) {
-  i['GoogleAnalyticsObject'] = r
-  ;(i[r] =
-    i[r] ||
-    function() {
-      ;(i[r].q = i[r].q || []).push(arguments)
-    }),
-    (i[r].l = 1 * new Date())
-  ;(a = s.createElement(o)), (m = s.getElementsByTagName(o)[0])
-  a.async = 1
-  a.src = g
-  m.parentNode.insertBefore(a, m)
-})(
-  window,
-  document,
-  'script',
-  'https://www.google-analytics.com/analytics.js',
-  'ga'
-)
-ga('create', 'UA-40502013-5', 'auto')
-ga('send', 'pageview')
-</script></body></html>

--- a/src/pages/Post.vue
+++ b/src/pages/Post.vue
@@ -73,7 +73,7 @@ export default {
     return {
       title: this.post.title,
       meta: [
-        { name: 'description', content: this.post.subtitle },
+        { name: 'description', content: this.post.description },
         { name: 'keywords', content: this.post.tags.join(',') },
         { name: 'author', content: this.post.author }
       ],


### PR DESCRIPTION
GoogleBOTは時間をおいて作られた`<head>`を読んでくれないようなので、記事HTMLをすべて生成することにした(中身は動的)。

また、リダイレクトできない環境でも動かせるので、GitHubPagesやS3(設定なし)でも動くようになった